### PR TITLE
Rocko

### DIFF
--- a/recipes-extended/libarchive/libarchive_3.1.2.%.bbappend
+++ b/recipes-extended/libarchive/libarchive_3.1.2.%.bbappend
@@ -1,0 +1,1 @@
+inherit upx_compress

--- a/recipes-extended/libarchive/libarchive_3.3.%.bbappend
+++ b/recipes-extended/libarchive/libarchive_3.3.%.bbappend
@@ -1,1 +1,0 @@
-inherit upx_compress


### PR DESCRIPTION
Fix telnet Warning on DM800HD

Fix Warning when extracting archive entry on DM800HD ..
"Warning when extracting archive entry '/usr/': Can't restore time"

https://github.com/MastaG/pli-oe-core/commit/3091b4dcdf7333693be81bd30e59d554ca0d1628